### PR TITLE
Fix capitalization in a README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ declare_types! {
 ```shell
 $ irb
 >> require "console/native"
->> Console.new.log("I'm in your rust")
+>> Console.new.log("I'm in your Rust")
 LOG: I'm in your Rust
 ```
 


### PR DESCRIPTION
Tiny fix. Make the input and output match capitalization. (Lowercasing "Rust" in the output would also fix this of course.)