### PR TITLE
Switch to using a new cstr!() macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ include = [
 
 [workspace]
 
-members = ["crates/libcruby-sys", "examples/calculator", "examples/console", "examples/duration", "examples/membership", "examples/turbo_blank"]
+members = ["examples/calculator", "examples/console", "examples/duration", "examples/membership", "examples/turbo_blank"]
 
 [dependencies]
 libc = "0.2.0"
@@ -21,3 +21,6 @@ version = "0.2"
 [dependencies.libcruby-sys]
 path = "crates/libcruby-sys"
 version = "0.5.0"
+
+[dependencies.cstr-macro]
+path = "crates/cstr-macro"

--- a/crates/cstr-macro/Cargo.toml
+++ b/crates/cstr-macro/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "cstr-macro"
+version = "0.1.0"
+authors = ["Godfrey Chan <godfreykfc@gmail.com>"]
+
+[dependencies]

--- a/crates/cstr-macro/src/lib.rs
+++ b/crates/cstr-macro/src/lib.rs
@@ -1,0 +1,29 @@
+#[macro_export]
+macro_rules! cstr {
+    ($s:expr) => (
+        concat!($s, "\0") as *const str as *const [::std::os::raw::c_char] as *const ::std::os::raw::c_char
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use ::std::ffi::CStr;
+    use ::std::os::raw::c_char;
+
+    #[test]
+    fn has_right_type() {
+        let val = cstr!("hello world");
+        assert_eq!(to_str(val), "hello world");
+    }
+
+    const hello: *const c_char = cstr!("hello");
+
+    #[test]
+    fn can_be_used_in_const_position() {
+        assert_eq!(to_str(hello), "hello");
+    }
+
+    fn to_str<'a>(input: *const c_char) -> &'a str {
+        unsafe { CStr::from_ptr(input) }.to_str().unwrap()
+    }
+}

--- a/src/class_definition.rs
+++ b/src/class_definition.rs
@@ -2,23 +2,26 @@ use libc;
 use std::ffi::CString;
 use { Class, sys };
 
-pub struct MethodSpecification<'a> {
-    name: &'a str,
-    function: *const libc::c_void,
+type c_string = *const libc::c_char;
+type void_ptr = *const libc::c_void;
+
+pub struct MethodSpecification {
+    name: c_string,
+    function: void_ptr,
     arity: isize,
 }
 
-pub enum MethodDefinition<'a> {
-    Class(MethodSpecification<'a>),
-    Instance(MethodSpecification<'a>)
+pub enum MethodDefinition {
+    Class(MethodSpecification),
+    Instance(MethodSpecification)
 }
 
-impl<'a> MethodDefinition<'a> {
-    pub fn class(name: &str, function: *const libc::c_void, arity: isize) -> MethodDefinition {
+impl MethodDefinition {
+    pub fn class(name: c_string, function: void_ptr, arity: isize) -> MethodDefinition {
         MethodDefinition::Class(MethodSpecification { name: name, function: function, arity: arity })
     }
 
-    pub fn instance(name: &str, function: *const libc::c_void, arity: isize) -> MethodDefinition {
+    pub fn instance(name: c_string, function: void_ptr, arity: isize) -> MethodDefinition {
         MethodDefinition::Instance(MethodSpecification { name: name, function: function, arity: arity })
     }
 }
@@ -28,20 +31,20 @@ pub struct ClassDefinition {
 }
 
 impl ClassDefinition {
-    pub fn new(name: &str) -> ClassDefinition {
-        let raw_class = unsafe { sys::rb_define_class(CString::new(name).unwrap().as_ptr(), sys::rb_cObject) };
+    pub fn new(name: c_string) -> ClassDefinition {
+        let raw_class = unsafe { sys::rb_define_class(name, sys::rb_cObject) };
         ClassDefinition { class: Class(raw_class) }
     }
 
-    pub fn wrapped(name: &str, alloc_func: extern "C" fn(klass: sys::VALUE) -> sys::VALUE) -> ClassDefinition {
-        let raw_class = unsafe { sys::rb_define_class(CString::new(name).unwrap().as_ptr(), sys::rb_cObject) };
+    pub fn wrapped(name: c_string, alloc_func: extern "C" fn(klass: sys::VALUE) -> sys::VALUE) -> ClassDefinition {
+        let raw_class = unsafe { sys::rb_define_class(name, sys::rb_cObject) };
         unsafe { sys::rb_define_alloc_func(raw_class, alloc_func) };
         ClassDefinition { class: Class(raw_class) }
     }
 
-    pub fn reopen(name: &str) -> ClassDefinition {
+    pub fn reopen(name: c_string) -> ClassDefinition {
         let raw_class = unsafe {
-            let class_id = sys::rb_intern(CString::new(name).unwrap().as_ptr());
+            let class_id = sys::rb_intern(name);
             sys::rb_const_get(sys::rb_cObject, class_id)
         };
         ClassDefinition { class: Class(raw_class) }
@@ -53,7 +56,7 @@ impl ClassDefinition {
                 unsafe {
                     sys::rb_define_method(
                         self.class.0,
-                        CString::new(def.name).unwrap().as_ptr(),
+                        def.name,
                         def.function,
                         def.arity
                     );
@@ -63,7 +66,7 @@ impl ClassDefinition {
                 unsafe {
                     sys::rb_define_singleton_method(
                         self.class.0,
-                        CString::new(def.name).unwrap().as_ptr(),
+                        def.name,
                         def.function,
                         def.arity
                     );

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -119,7 +119,7 @@ macro_rules! class_definition {
                     Ok(rust_self.$name($($arg),*))
                 }
 
-                let name = stringify!($name);
+                let name = cstr!(stringify!($name));
                 let arity = method_arity!($($arg),*);
                 let method = __ruby_method__ as *const $crate::libc::c_void;
 
@@ -159,7 +159,7 @@ macro_rules! class_definition {
                     Ok($cls::$name($($arg),*))
                 }
 
-                let name = stringify!($name);
+                let name = cstr!(stringify!($name));
                 let arity = method_arity!($($arg),*);
                 let method = __ruby_method__ as *const $crate::libc::c_void;
 
@@ -354,10 +354,10 @@ macro_rules! class_definition {
                 let arity = method_arity!($($arg),*);
                 let method = __initialize__ as *const $crate::libc::c_void;
 
-                $crate::MethodDefinition::instance("initialize", method, arity)
+                $crate::MethodDefinition::instance(cstr!("initialize"), method, arity)
             };
 
-            let def = $crate::ClassDefinition::wrapped(stringify!($cls), __alloc__)
+            let def = $crate::ClassDefinition::wrapped(cstr!(stringify!($cls)), __alloc__)
                 .define_method(def_initialize)
                 $(.define_method($mdef))*;
 
@@ -371,7 +371,7 @@ macro_rules! class_definition {
         static mut __HELIX_ID: usize = 0;
 
         init! {
-            let def = $crate::ClassDefinition::new(stringify!($cls))$(.define_method($mdef))*;
+            let def = $crate::ClassDefinition::new(cstr!(stringify!($cls)))$(.define_method($mdef))*;
             unsafe { __HELIX_ID = ::std::mem::transmute(def.class) };
         }
     };
@@ -382,7 +382,7 @@ macro_rules! class_definition {
         static mut __HELIX_ID: usize = 0;
 
         init! {
-            let def = $crate::ClassDefinition::reopen(stringify!($cls))$(.define_method($mdef))*;
+            let def = $crate::ClassDefinition::reopen(cstr!(stringify!($cls)))$(.define_method($mdef))*;
             unsafe { __HELIX_ID = ::std::mem::transmute(def.class) };
         }
     };
@@ -518,3 +518,14 @@ macro_rules! method_arity {
     { 0isize $(+ replace_expr!($id 1isize))* }
   }
 }
+
+// This macro is copied instead of depended upon because of https://github.com/rust-lang/rust/issues/29638
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! cstr {
+    ($s:expr) => (
+        concat!($s, "\0") as *const str as *const [::std::os::raw::c_char] as *const ::std::os::raw::c_char
+    )
+}
+


### PR DESCRIPTION
Unlike the previous Cstring::new approach, this approach doesn't
allocate. This will become important when we start using rb_raise
(which takes a C string but longjmps and therefore doesn't clean up
the memory).

(we got this implementation from @ubsan -- thanks!)