### PR TITLE
Better function calls

### DIFF
--- a/crates/libcruby-sys/src/macros.rs
+++ b/crates/libcruby-sys/src/macros.rs
@@ -1,0 +1,142 @@
+// TODO: See if we can simplify
+#[doc(hidden)]
+#[macro_export]
+macro_rules! ruby_extern_fns {
+    // We don't need the body here
+    { #[$attr:meta] $name:ident($( $argn:ident: $argt:ty ),*) -> $ret:ty { $($_body:tt)* } $($rest:tt)* } => {
+        ruby_extern_fns! { #[$attr] $name($( $argn: $argt ),*) -> $ret; $($rest)* } };
+
+    { #[$attr:meta] $name:ident($( $argn:ident: $argt:ty ),*) -> $ret:ty; $($rest:tt)* } => {
+        #[cfg_attr(windows, link(name="helix-runtime"))]
+        extern "C" {
+            #[$attr]
+            pub fn $name($($argn: $argt),*) -> $ret;
+        }
+        ruby_extern_fns! { $($rest)* }
+    };
+    { #[$attr:meta] $name:ident($( $argn:ident: $argt:ty ),*); $($rest:tt)* } => {
+        #[cfg_attr(windows, link(name="helix-runtime"))]
+        extern "C" {
+            #[$attr]
+            pub fn $name($($argn: $argt),*);
+        }
+        ruby_extern_fns! { $($rest)* }
+    };
+
+    // We don't need the body here
+    { $name:ident($( $argn:ident: $argt:ty ),*) -> $ret:ty { $($_body:tt)* } $($rest:tt)* } => {
+        ruby_extern_fns! { $name($( $argn: $argt ),*) -> $ret; $($rest)* } };
+
+    { $name:ident($( $argn:ident: $argt:ty ),*) -> $ret:ty; $($rest:tt)* } => {
+        #[cfg_attr(windows, link(name="helix-runtime"))]
+        extern "C" { pub fn $name($($argn: $argt),*) -> $ret; }
+        ruby_extern_fns! { $($rest)* }
+    };
+    { $name:ident($( $argn:ident: $argt:ty ),*); $($rest:tt)* } => {
+        #[cfg_attr(windows, link(name="helix-runtime"))]
+        extern "C" { pub fn $name($($argn: $argt),*); }
+        ruby_extern_fns! { $($rest)* }
+    };
+
+    { } => ()
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! ruby_safe_fn {
+    { $name:ident($( $argn:ident: $argt:ty ),*) -> $ret:ty { $($funcs:tt)+ } } => {
+        pub fn $name($( $argn: $argt ),*) -> Result<$ret, $crate::RubyException> {
+            // FIXME: Avoid creating args struct if there are no args
+            #[repr(C)]
+            #[derive(Copy, Clone, Debug)]
+            struct Args {
+                pub $($argn: $argt),*
+            };
+
+            let args = Args { $($argn: $argn),* };
+
+            // Must include ret_to_ptr and ptr_to_ret
+            $($funcs)+
+
+            extern "C" fn cb(args_ptr: *mut $crate::void) -> *mut $crate::void {
+                let ret = unsafe {
+                    let args: &Args = &*(args_ptr as *const Args);
+                    $crate::$name($( args.$argn ),*)
+                };
+                ret_to_ptr(ret)
+            }
+
+            let mut state = $crate::EMPTY_EXCEPTION;
+
+            let res = unsafe {
+                let args_ptr: *mut $crate::void = &args as *const _ as *mut $crate::void;
+                $crate::rb_protect(cb, args_ptr, &mut state)
+            };
+
+            if !state.is_empty() {
+                Err(state)
+            } else {
+                Ok(ptr_to_ret(res))
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! ruby_safe_fns {
+    // We don't need the meta here
+    { #[$attr:meta] $($rest:tt)* } => {
+        ruby_safe_fns! { $($rest)* }
+    };
+
+    // It's not quite ideal to have to define each type separately, but the coercions are different
+    { $name:ident($( $argn:ident: $argt:ty ),*) -> VALUE; $($rest:tt)* } => {
+        ruby_safe_fn! {
+            $name($( $argn: $argt ),*) -> $crate::VALUE {
+                fn ret_to_ptr(ret: $crate::VALUE) -> *mut $crate::void { ret.as_ptr() }
+                fn ptr_to_ret(ptr: *mut $crate::void) -> $crate::VALUE { $crate::VALUE::wrap(ptr) }
+            }
+        }
+
+        ruby_safe_fns! { $($rest)* }
+    };
+
+    { $name:ident($( $argn:ident: $argt:ty ),*) -> $ret:ty { $($conv:tt)* } $($rest:tt)* } => {
+        ruby_safe_fn! {
+            $name($( $argn: $argt ),*) -> $ret { $($conv)* }
+        }
+
+        ruby_safe_fns! { $($rest)* }
+    };
+
+    { $name:ident($( $argn:ident: $argt:ty ),*); $($rest:tt)* } => {
+        ruby_safe_fn! {
+            $name($( $argn: $argt ),*) -> () {
+                fn ret_to_ptr(_: ()) -> *mut $crate::void { unsafe { $crate::Qnil }.as_ptr() }
+                fn ptr_to_ret(_: *mut $crate::void) { }
+            }
+        }
+
+        ruby_safe_fns! { $($rest)* }
+    };
+
+    { } => ()
+}
+
+#[macro_export]
+macro_rules! ruby_safe_c {
+    { $($parts:tt)+ } => {
+        ruby_extern_fns! {
+            $($parts)+
+        }
+
+        pub mod safe {
+            use $crate::*;
+
+            ruby_safe_fns! {
+                $($parts)+
+            }
+        }
+    }
+}

--- a/examples/console/lib/console.rb
+++ b/examples/console/lib/console.rb
@@ -1,2 +1,8 @@
 require 'helix_runtime'
 require 'console/native'
+
+class Console
+  def ruby_hello
+    "hello"
+  end
+end

--- a/examples/console/spec/console_spec.rb
+++ b/examples/console/spec/console_spec.rb
@@ -65,4 +65,15 @@ describe "Console" do
       expect { console.log(str) }.to raise_error(TypeError, "Expected a valid UTF-8 String, got #{str.inspect}")
     end
   end
+
+  it "can handle calls back to Ruby" do
+    expect(console.call_ruby).to eq("\"Object\", true, true")
+  end
+
+  it "can handle invalid calls back to Ruby" do
+    # NOTE: This doesn't verify that Rust unwound correctly
+    expect {
+      console.behave_badly
+    }.to raise_error(NameError, "undefined method `does_not_exist' for Object:Class");
+  end
 end

--- a/examples/console/spec/spec_helper.rb
+++ b/examples/console/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'console'
 
 module PrintMatchers
   def print(expected = nil)
-    output(expected = nil).to_stdout_from_any_process
+    output(expected).to_stdout_from_any_process
   end
 
   def println(expected)

--- a/examples/console/src/lib.rs
+++ b/examples/console/src/lib.rs
@@ -2,6 +2,7 @@
 
 #[macro_use]
 extern crate helix;
+use helix::{sys,FromRuby};
 
 ruby! {
     #[derive(Debug)]
@@ -52,6 +53,17 @@ ruby! {
 
         def panic(&self) {
             panic!("raised from Rust with `panic`");
+        }
+
+        def behave_badly(&self) {
+            ruby_funcall!(sys::rb_cObject, "does_not_exist", String::from("one"));
+        }
+
+        def call_ruby(&self) -> String {
+            let a = ruby_funcall!(sys::rb_cObject, "name"); // No arg
+            let b = ruby_funcall!(sys::rb_cObject, "is_a?", sys::rb_cObject); // One arg
+            let c = ruby_funcall!(sys::rb_cObject, "respond_to?", String::from("inspect"), true); // Two args
+            format!("{:?}, {:?}, {:?}", String::from_ruby_unwrap(a), bool::from_ruby_unwrap(b), bool::from_ruby_unwrap(c))
         }
     }
 }

--- a/ruby/lib/helix_runtime/project.rb
+++ b/ruby/lib/helix_runtime/project.rb
@@ -87,12 +87,18 @@ module HelixRuntime
       env = {}
       env['HELIX_LIB_DIR'] = helix_lib_dir if helix_lib_dir
 
+      nightly = false
       cargo_args = []
       rustc_args = []
 
-      if ENV['DEBUG_RUST_MACROS']
+      if ENV['EXPAND_MACROS']
         rustc_args << "--pretty expanded"
         rustc_args << "-Z unstable-options"
+        nightly = true
+      end
+      if ENV['TRACE_MACROS']
+        rustc_args << "-Z external-macro-backtrace"
+        nightly = true
       end
       unless debug_rust?
         cargo_args << ["--release"]
@@ -108,7 +114,10 @@ module HelixRuntime
         cargo_args << "-- #{rustc_args.join(' ')}"
       end
 
-      run env, "cargo rustc #{cargo_args.join(' ')}"
+      cmd = "cargo rustc #{cargo_args.join(' ')}"
+      cmd = "rustup run nightly #{cmd}" if nightly
+
+      run env, cmd
     end
 
     def cargo_clean

--- a/src/class_definition.rs
+++ b/src/class_definition.rs
@@ -28,45 +28,39 @@ pub struct ClassDefinition {
 
 impl ClassDefinition {
     pub fn new(name: c_string) -> ClassDefinition {
-        let raw_class = unsafe { sys::rb_define_class(name, sys::rb_cObject) };
+        let raw_class = ruby_try!(sys::safe::rb_define_class(name, unsafe { sys::rb_cObject }));
         ClassDefinition { class: Class(raw_class) }
     }
 
     pub fn wrapped(name: c_string, alloc_func: extern "C" fn(klass: sys::VALUE) -> sys::VALUE) -> ClassDefinition {
-        let raw_class = unsafe { sys::rb_define_class(name, sys::rb_cObject) };
-        unsafe { sys::rb_define_alloc_func(raw_class, alloc_func) };
+        let raw_class = ruby_try!(sys::safe::rb_define_class(name, unsafe { sys::rb_cObject }));
+        ruby_try!(sys::safe::rb_define_alloc_func(raw_class, alloc_func));
         ClassDefinition { class: Class(raw_class) }
     }
 
     pub fn reopen(name: c_string) -> ClassDefinition {
-        let raw_class = unsafe {
-            let class_id = sys::rb_intern(name);
-            sys::rb_const_get(sys::rb_cObject, class_id)
-        };
+        let class_id = unsafe { sys::rb_intern(name) };
+        let raw_class = ruby_try!(sys::safe::rb_const_get(unsafe { sys::rb_cObject }, class_id));
         ClassDefinition { class: Class(raw_class) }
     }
 
     pub fn define_method(&self, def: MethodDefinition) {
         match def {
             MethodDefinition::Instance(def) => {
-                unsafe {
-                    sys::rb_define_method(
-                        self.class.0,
-                        def.name,
-                        def.function,
-                        def.arity
-                    );
-                };
+                ruby_try!(sys::safe::rb_define_method(
+                    self.class.0,
+                    def.name,
+                    def.function,
+                    def.arity
+                ));
             },
             MethodDefinition::Class(def) => {
-                unsafe {
-                    sys::rb_define_singleton_method(
-                        self.class.0,
-                        def.name,
-                        def.function,
-                        def.arity
-                    );
-                };
+                ruby_try!(sys::safe::rb_define_singleton_method(
+                    self.class.0,
+                    def.name,
+                    def.function,
+                    def.arity
+                ));
             }
         }
     }

--- a/src/coercions/mod.rs
+++ b/src/coercions/mod.rs
@@ -12,7 +12,7 @@ mod slice;
 mod vec;
 mod hash;
 
-use sys::{VALUE};
+use sys::VALUE;
 use super::{Error, ToError};
 use std::marker::{PhantomData, Sized};
 

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -13,6 +13,9 @@ mod coercions;
 #[macro_use]
 mod alloc;
 
+#[macro_use]
+mod safe;
+
 #[macro_export]
 macro_rules! ruby {
     { $($rest:tt)* } => {

--- a/src/macros/safe.rs
+++ b/src/macros/safe.rs
@@ -1,0 +1,51 @@
+// TODO: Can we change this to use the macro from libcruby?
+#[macro_export]
+macro_rules! ruby_try {
+    { $val:expr } => { $val.unwrap_or_else(|e| panic!($crate::Error::from_ruby(e)) ) }
+}
+
+#[macro_export]
+macro_rules! ruby_funcall {
+    // NOTE: Class and method cannot be variables. If that becomes necessary, I think we'll have to pass them
+    ($rb_class:expr, $meth:expr, $( $arg:expr ),*) => {
+        {
+            use $crate::ToRuby;
+
+            // This method takes a Ruby Array of arguments
+            // If there is a way to make this behave like a closure, we could further simplify things.
+            #[allow(unused_variables)]
+            extern "C" fn __ruby_funcall_cb(arg_ary: *mut $crate::sys::void) -> *mut $crate::sys::void {
+                unsafe {
+                    // Is this safe here?
+                    let arg_ary = $crate::sys::VALUE::wrap(arg_ary);
+                    // NOTE: We're using rb_intern_str, not rb_intern in the hopes that this means
+                    //   Ruby will clean up the string in the event that there is an exception
+                    $crate::sys::rb_funcallv($rb_class, sys::rb_intern_str(String::from($meth).to_ruby().expect("valid string")),
+                                                $crate::sys::RARRAY_LEN(arg_ary), $crate::sys::RARRAY_PTR(arg_ary)).as_ptr()
+                }
+            }
+
+            let mut state = $crate::sys::EMPTY_EXCEPTION;
+
+            let res = unsafe {
+                let mut values_ary: Vec<$crate::sys::VALUE> = Vec::new();
+                $(
+                    // We have to create this iteratively since we have to call to_ruby individually
+                    values_ary.push($arg.to_ruby().expect("could convert to Ruby"));
+                )*
+                let ruby_values_ary = $crate::sys::rb_ary_new_from_values(values_ary.len() as isize, values_ary.as_mut_ptr());
+                $crate::sys::rb_protect(__ruby_funcall_cb, ruby_values_ary.as_ptr(), &mut state)
+            };
+
+            if !state.is_empty() {
+                panic!($crate::Error::from_ruby(state));
+            }
+
+            $crate::sys::VALUE::wrap(res)
+        }
+    };
+
+    ($rb_class:expr, $meth:expr) => {
+        ruby_funcall!($rb_class, $meth, )
+    }
+}


### PR DESCRIPTION
1. Wraps dangerous calls from Rust into Ruby in rb_protect to ensure that we correctly unwind in Rust before re-raising the error.
2. Provides a ruby_funcall! macro to safely call Ruby functions from Rust code.