### PR TITLE
Bump cslice crate: 0.2 -> 0.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = ["examples/calculator", "examples/console", "examples/duration", "exam
 libc = "0.2.0"
 
 [dependencies.cslice]
-version = "0.2"
+version = "0.3"
 
 [dependencies.libcruby-sys]
 path = "crates/libcruby-sys"


### PR DESCRIPTION
Diff: https://github.com/dherman/cslice/compare/1522f67...e6ad