### PR TITLE
Add metadata to gemspec

### DIFF
--- a/ruby/helix_runtime.gemspec
+++ b/ruby/helix_runtime.gemspec
@@ -12,6 +12,12 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{The Helix Runtime}
   spec.homepage      = "https://usehelix.com"
 
+  spec.metadata      = {
+    "bug_tracker_uri" => "https://github.com/tildeio/helix/issues",
+    "changelog_uri"   => "https://github.com/tildeio/helix/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/tildeio/helix",
+  }
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "bin"
   spec.extensions    = ["ext/helix_runtime/native/extconf.rb"]


### PR DESCRIPTION
I was trying to find the repo from Rubygems, and realised that unlike most gems I've come across, it doesn't link to the GitHub repository. So, this change added all the metadata that seemed appropriate to the gem spec.