### PR TITLE
Use build task name as project name

### DIFF
--- a/ruby/lib/helix_runtime/build_task.rb
+++ b/ruby/lib/helix_runtime/build_task.rb
@@ -11,14 +11,14 @@ module HelixRuntime
     end
 
     def project
-      @project ||= Project.new(Dir.pwd)
+      @project ||= Project.new(@name, Dir.pwd)
     end
 
-    delegate_attr :name,           to: :project
     delegate_attr :helix_lib_dir,  to: :project
     delegate_attr :debug_rust,     to: :project
     delegate_attr :build_root,     to: :project
 
+    attr_reader :name
     attr_accessor :pre_build
 
     def initialize(name = nil, gem_spec = nil)

--- a/ruby/lib/helix_runtime/parent_project.rb
+++ b/ruby/lib/helix_runtime/parent_project.rb
@@ -10,7 +10,7 @@ module HelixRuntime
     def projects
       @projects ||= Dir["#{root}/crates/*"]
                         .select{|f| File.exist?("#{f}/Cargo.toml") }
-                        .map{|d| Project.new(d) }
+                        .map{|d| Project.new(File.basename(d), d) }
     end
 
     def ensure_built!

--- a/ruby/lib/helix_runtime/project.rb
+++ b/ruby/lib/helix_runtime/project.rb
@@ -13,9 +13,9 @@ module HelixRuntime
     attr_accessor :debug_rust
     attr_accessor :build_root
 
-    def initialize(root)
+    def initialize(name, root)
       @root = find_root(root)
-      @name = File.basename(@root)
+      @name = name
       @debug_rust = ENV['DEBUG_RUST']
       @build_root = @root
     end


### PR DESCRIPTION
Fix building when project name in HelixRuntime::BuildTask is different then the root directory name.

If the project name in Rake task and directory name do not match, running `rake build` fails with an error message like

```
native source doesn't exist, run `cargo_build` first; source=/Users/lautis/Git/rscsv-2/target/release/librscsv-2.dylib
```

This especially annoying if the build task is run during gem installation. In that case the directory name is `<gem-name>-<version>`.