### PR TITLE
Add missing type annotation to transmute call

### DIFF
--- a/src/macros/coercions.rs
+++ b/src/macros/coercions.rs
@@ -12,6 +12,7 @@ macro_rules! codegen_coercions {
                 use $crate::{CheckedValue, sys};
                 use ::std::ffi::{CStr};
 
+                // Explicit `usize` fixes https://github.com/tildeio/helix/pull/93.
                 if unsafe { $cls == ::std::mem::transmute::<_, usize>(sys::rb_obj_class(self)) } {
                     Ok(unsafe { CheckedValue::new(self) })
                 } else {

--- a/src/macros/coercions.rs
+++ b/src/macros/coercions.rs
@@ -12,7 +12,7 @@ macro_rules! codegen_coercions {
                 use $crate::{CheckedValue, sys};
                 use ::std::ffi::{CStr};
 
-                if unsafe { $cls == ::std::mem::transmute(sys::rb_obj_class(self)) } {
+                if unsafe { $cls == ::std::mem::transmute::<_, usize>(sys::rb_obj_class(self)) } {
                     Ok(unsafe { CheckedValue::new(self) })
                 } else {
                     let val = unsafe { CStr::from_ptr(sys::rb_obj_classname(self)).to_string_lossy() };

--- a/src/macros/coercions.rs
+++ b/src/macros/coercions.rs
@@ -82,7 +82,7 @@ macro_rules! impl_struct_to_rust {
                 use $crate::{CheckedValue, sys};
                 use ::std::ffi::{CStr};
 
-                if unsafe { $helix_id == ::std::mem::transmute(sys::rb_obj_class(self)) } {
+                if unsafe { $helix_id == ::std::mem::transmute::<_, usize>(sys::rb_obj_class(self)) } {
                     if unsafe { $crate::sys::Data_Get_Struct_Value(self) == ::std::ptr::null_mut() } {
                         Err(format!("Uninitialized {}", $crate::inspect(unsafe { sys::rb_obj_class(self) })))
                     } else {

--- a/src/macros/init.rs
+++ b/src/macros/init.rs
@@ -30,7 +30,7 @@ macro_rules! codegen_class_binding {
             codegen_define_method!(def, $class, $method);
         )*
 
-        unsafe { $name = transmute(def.class) };
+        unsafe { $name = transmute::<_, usize>(def.class) };
     });
 
     { $class:tt, {
@@ -47,7 +47,7 @@ macro_rules! codegen_class_binding {
             codegen_define_method!(def, $class, $method);
         )*
 
-        unsafe { $name = transmute(def.class) };
+        unsafe { $name = transmute::<_, usize>(def.class) };
     });
 
     { $class:tt, {
@@ -69,7 +69,7 @@ macro_rules! codegen_class_binding {
             codegen_define_method!(def, $class, $method);
         )*
 
-        unsafe { $cls = transmute(def.class) }
+        unsafe { $cls = transmute::<_, usize>(def.class) }
     });
 
 }


### PR DESCRIPTION
When adding serde_json to a Helix crate, Helix class definitions stop compiling, complaining about a missing memory error deep within the bowels of Helix's macros.

This commit PR that missing typecast.

Now, I can't tell you _why_ adding serde_json triggers this error, but it definitely comes from Helix's macros, and this change definitely fixes it.