### PR TITLE
Don't touch native projects.

### DIFF
--- a/ruby/lib/helix_runtime/project.rb
+++ b/ruby/lib/helix_runtime/project.rb
@@ -23,6 +23,10 @@ module HelixRuntime
     def debug_rust?
       !!debug_rust
     end
+    
+    def has_gemfile?
+      File.exist?("#{root}/Gemfile")
+    end  
 
     def build_path
       File.expand_path(debug_rust? ? 'target/debug' : 'target/release', build_root)
@@ -45,6 +49,7 @@ module HelixRuntime
     end
 
     def outdated_build?
+      return false unless has_gemfile?
       mtime = Dir["#{root}/src/**/*.rs"].map{|file| File.mtime(file) }.max
       native = "#{root}/lib/#{name}/native.#{Platform.dlext}"
       !File.exist?(native) || File.mtime(native) < mtime
@@ -105,6 +110,7 @@ module HelixRuntime
     end
 
     def copy_native
+      return unless has_gemfile?
       source = "#{build_path}/#{native_lib}"
       raise "native source doesn't exist, run `cargo_build` first; source=#{source}" unless File.exist?(source)
       FileUtils.mkdir_p(File.dirname(native_path))


### PR DESCRIPTION
Here was a trouble with false positive checking for library binaries, even if we have binary projects (CLI and so on). So i think better don't touch projects without Gemfile inside.