### PR TITLE
Allow any closure to be used with catch_panic

### DIFF
--- a/src/macros/init.rs
+++ b/src/macros/init.rs
@@ -331,9 +331,11 @@ macro_rules! handle_exception {
             }));
         }
 
-        let res = ::std::panic::catch_unwind(|| {
+        // TODO: Poison any objects that cross the boundary to prevent them
+        // from being used in Ruby and triggering panics over and over again.
+        let res = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| {
             $($body)*
-        });
+        }));
 
         if hide_err {
             let _ = ::std::panic::take_hook();


### PR DESCRIPTION
Asserting unwind safe is supposed to mean that we poison mutable object
involved in the panic (to prevent objects that were involved in panics
from triggering errors over and over again) and we should do that in the
future.

Fixes https://gist.github.com/citizen428/fd4fb386d6a78f09e217f1fe9d01834c

/cc @citizen428