### PR TITLE
Fix compat with serde_json

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,10 @@ pub fn inspect(val: VALUE) -> String {
     unsafe { CheckedValue::<String>::new(sys::rb_inspect(val)).to_rust() }
 }
 
+pub unsafe fn as_usize(value: ::VALUE) -> usize {
+    std::mem::transmute(value)
+}
+
 pub type Metadata = ::VALUE;
 
 #[derive(Copy, Clone, Debug)]

--- a/src/macros/coercions.rs
+++ b/src/macros/coercions.rs
@@ -12,7 +12,7 @@ macro_rules! codegen_coercions {
                 use $crate::{CheckedValue, sys};
                 use ::std::ffi::{CStr};
 
-                if unsafe { $cls == ::std::mem::transmute(sys::rb_obj_class(self)) } {
+                if unsafe { $cls == $crate::as_usize(sys::rb_obj_class(self)) } {
                     Ok(unsafe { CheckedValue::new(self) })
                 } else {
                     let val = unsafe { CStr::from_ptr(sys::rb_obj_classname(self)).to_string_lossy() };
@@ -81,7 +81,7 @@ macro_rules! impl_struct_to_rust {
                 use $crate::{CheckedValue, sys};
                 use ::std::ffi::{CStr};
 
-                if unsafe { $helix_id == ::std::mem::transmute(sys::rb_obj_class(self)) } {
+                if unsafe { $helix_id == $crate::as_usize(sys::rb_obj_class(self)) } {
                     if unsafe { $crate::sys::Data_Get_Struct_Value(self) == ::std::ptr::null_mut() } {
                         Err(format!("Uninitialized {}", $crate::inspect(unsafe { sys::rb_obj_class(self) })))
                     } else {


### PR DESCRIPTION
The previous code was relying on the accidental fact that only a single
impl of PartialEq<usize> existed. serde_json defines another impl of
PartialEq<usize>, which causes the constraint to be insufficient, which
results in a compile error when serde_json is added to a project with
Helix.

This commit forces the VALUE into a usize eagerly, avoiding this
inference issue.

Fixes #93

h/t @alyssais

Thanks to @nikomatsakis for helping me figure out the root cause.