### PR TITLE
Deprecate passing project name to `BuildTask`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2 (Unreleased)
+
+* [DEPRECATION] Deprecate passing project name to `BuildTask`
+
 ## 0.6.1 (May 18, 2017)
 
 * [BUGFIX] Fix path in copy_dll task for Windows installation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.2 (Unreleased)
+## 0.6.2 (August 29, 2017)
 
 * [DEPRECATION] Deprecate passing project name to `BuildTask`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helix"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Godhuda <engineering+godhuda@tilde.io>"]
 description = "Embed Rust in your Ruby"
 documentation = "https://usehelix.com/documentation"
@@ -31,7 +31,7 @@ version = "0.3"
 
 [dependencies.libcruby-sys]
 path = "crates/libcruby-sys"
-version = "0.6.1"
+version = "0.6.2"
 
 [dependencies.cstr-macro]
 path = "crates/cstr-macro"

--- a/crates/libcruby-sys/Cargo.toml
+++ b/crates/libcruby-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libcruby-sys"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Godhuda <engineering+godhuda@tilde.io>"]
 description = "Ruby bindings"
 repository = "https://github.com/tildeio/helix"
@@ -11,8 +11,8 @@ include = [
     "Cargo.toml",
     "ruby_info.rb",
     # Keep in sync with version
-    "helix-runtime-0-6-1.i386.lib",
-    "helix-runtime-0-6-1.x86_64.lib"
+    "helix-runtime-0-6-2.i386.lib",
+    "helix-runtime-0-6-2.x86_64.lib"
 ]
 
 [dependencies]

--- a/examples/calculator/Gemfile.lock
+++ b/examples/calculator/Gemfile.lock
@@ -1,15 +1,19 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.0)
+    helix_runtime (0.6.1)
       rake (>= 10.0)
       thor (~> 0.19.4)
+      toml (~> 0.1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    blankslate (2.1.2.4)
     colorize (0.8.1)
     diff-lcs (1.3)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
     rake (10.4.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -25,6 +29,8 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thor (0.19.4)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
 
 PLATFORMS
   ruby

--- a/examples/calculator/Gemfile.lock
+++ b/examples/calculator/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.1)
+    helix_runtime (0.6.2)
       rake (>= 10.0)
       thor (~> 0.19.4)
       toml (~> 0.1.2)

--- a/examples/calculator/Rakefile
+++ b/examples/calculator/Rakefile
@@ -6,7 +6,7 @@ require_relative '../shared.rb'
 # For Windows
 $stdout.sync = true
 
-HelixRuntime::BuildTask.new("calculator") do |t|
+HelixRuntime::BuildTask.new do |t|
   t.build_root = File.expand_path("../..", __dir__)
   t.helix_lib_dir = File.expand_path("../../ruby/windows_build", __dir__)
   t.pre_build = HelixRuntime::Tests.pre_build

--- a/examples/console/Gemfile.lock
+++ b/examples/console/Gemfile.lock
@@ -1,15 +1,19 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.0)
+    helix_runtime (0.6.1)
       rake (>= 10.0)
       thor (~> 0.19.4)
+      toml (~> 0.1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    blankslate (2.1.2.4)
     colorize (0.8.1)
     diff-lcs (1.3)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -25,6 +29,8 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thor (0.19.4)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
 
 PLATFORMS
   ruby

--- a/examples/console/Gemfile.lock
+++ b/examples/console/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.1)
+    helix_runtime (0.6.2)
       rake (>= 10.0)
       thor (~> 0.19.4)
       toml (~> 0.1.2)

--- a/examples/console/Rakefile
+++ b/examples/console/Rakefile
@@ -6,7 +6,7 @@ require_relative '../shared.rb'
 # For Windows
 $stdout.sync = true
 
-HelixRuntime::BuildTask.new("console") do |t|
+HelixRuntime::BuildTask.new do |t|
   t.build_root = File.expand_path("../..", __dir__)
   t.helix_lib_dir = File.expand_path("../../ruby/windows_build", __dir__)
   t.pre_build = HelixRuntime::Tests.pre_build

--- a/examples/duration/Gemfile.lock
+++ b/examples/duration/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.0)
+    helix_runtime (0.6.1)
       rake (>= 10.0)
       thor (~> 0.19.4)
+      toml (~> 0.1.2)
 
 PATH
   remote: .
@@ -19,12 +20,17 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    blankslate (2.1.2.4)
     concurrent-ruby (1.0.5)
     i18n (0.8.1)
     minitest (5.8.3)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
     rake (10.5.0)
     thor (0.19.4)
     thread_safe (0.3.6)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 

--- a/examples/duration/Gemfile.lock
+++ b/examples/duration/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.1)
+    helix_runtime (0.6.2)
       rake (>= 10.0)
       thor (~> 0.19.4)
       toml (~> 0.1.2)

--- a/examples/duration/Rakefile
+++ b/examples/duration/Rakefile
@@ -6,7 +6,7 @@ require_relative '../shared.rb'
 # For Windows
 $stdout.sync = true
 
-HelixRuntime::BuildTask.new("duration") do |t|
+HelixRuntime::BuildTask.new do |t|
   t.build_root = File.expand_path("../..", __dir__)
   t.helix_lib_dir = File.expand_path("../../ruby/windows_build", __dir__)
   t.pre_build = HelixRuntime::Tests.pre_build

--- a/examples/membership/Gemfile.lock
+++ b/examples/membership/Gemfile.lock
@@ -1,14 +1,18 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.0)
+    helix_runtime (0.6.1)
       rake (>= 10.0)
       thor (~> 0.19.4)
+      toml (~> 0.1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    blankslate (2.1.2.4)
     diff-lcs (1.2.5)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
     rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -24,6 +28,8 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     thor (0.19.4)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
 
 PLATFORMS
   ruby

--- a/examples/membership/Gemfile.lock
+++ b/examples/membership/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.1)
+    helix_runtime (0.6.2)
       rake (>= 10.0)
       thor (~> 0.19.4)
       toml (~> 0.1.2)

--- a/examples/membership/Rakefile
+++ b/examples/membership/Rakefile
@@ -6,7 +6,7 @@ require_relative '../shared.rb'
 # For Windows
 $stdout.sync = true
 
-HelixRuntime::BuildTask.new("membership") do |t|
+HelixRuntime::BuildTask.new do |t|
   t.build_root = File.expand_path("../..", __dir__)
   t.helix_lib_dir = File.expand_path("../../ruby/windows_build", __dir__)
   t.pre_build = HelixRuntime::Tests.pre_build

--- a/examples/text_transform/Gemfile.lock
+++ b/examples/text_transform/Gemfile.lock
@@ -1,14 +1,18 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.0)
+    helix_runtime (0.6.1)
       rake (>= 10.0)
       thor (~> 0.19.4)
+      toml (~> 0.1.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    blankslate (2.1.2.4)
     diff-lcs (1.3)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -24,6 +28,8 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thor (0.19.4)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
 
 PLATFORMS
   ruby

--- a/examples/text_transform/Gemfile.lock
+++ b/examples/text_transform/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.1)
+    helix_runtime (0.6.2)
       rake (>= 10.0)
       thor (~> 0.19.4)
       toml (~> 0.1.2)

--- a/examples/text_transform/Rakefile
+++ b/examples/text_transform/Rakefile
@@ -6,7 +6,7 @@ require_relative '../shared.rb'
 # For Windows
 $stdout.sync = true
 
-HelixRuntime::BuildTask.new("text_transform") do |t|
+HelixRuntime::BuildTask.new do |t|
   t.build_root = File.expand_path("../..", __dir__)
   t.helix_lib_dir = File.expand_path("../../ruby/windows_build", __dir__)
   t.pre_build = HelixRuntime::Tests.pre_build

--- a/examples/turbo_blank/Gemfile.lock
+++ b/examples/turbo_blank/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.0)
+    helix_runtime (0.6.1)
       rake (>= 10.0)
       thor (~> 0.19.4)
+      toml (~> 0.1.2)
 
 PATH
   remote: .
@@ -14,9 +15,14 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    blankslate (2.1.2.4)
     minitest (5.8.3)
+    parslet (1.5.0)
+      blankslate (~> 2.0)
     rake (10.5.0)
     thor (0.19.4)
+    toml (0.1.2)
+      parslet (~> 1.5.0)
 
 PLATFORMS
   ruby

--- a/examples/turbo_blank/Gemfile.lock
+++ b/examples/turbo_blank/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../ruby
   specs:
-    helix_runtime (0.6.1)
+    helix_runtime (0.6.2)
       rake (>= 10.0)
       thor (~> 0.19.4)
       toml (~> 0.1.2)

--- a/examples/turbo_blank/Rakefile
+++ b/examples/turbo_blank/Rakefile
@@ -6,7 +6,7 @@ require_relative '../shared.rb'
 # For Windows
 $stdout.sync = true
 
-HelixRuntime::BuildTask.new("turbo_blank") do |t|
+HelixRuntime::BuildTask.new do |t|
   t.build_root = File.expand_path("../..", __dir__)
   t.helix_lib_dir = File.expand_path("../../ruby/windows_build", __dir__)
   t.pre_build = HelixRuntime::Tests.pre_build

--- a/ruby/ext/helix_runtime/native/helix_runtime.c
+++ b/ruby/ext/helix_runtime/native/helix_runtime.c
@@ -6,7 +6,7 @@
 #include <helix_runtime.h>
 
 // Update with version.rb
-const char* HELIX_RUNTIME_VERSION = "0.6.1";
+const char* HELIX_RUNTIME_VERSION = "0.6.2";
 
 const char* HELIX_PRIsVALUE = PRIsVALUE;
 const char* HELIX_SPRINTF_TO_S = "%" PRIsVALUE;

--- a/ruby/helix_runtime.gemspec
+++ b/ruby/helix_runtime.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rake", ">= 10.0"
   spec.add_dependency "thor", "~> 0.19.4"
+  spec.add_dependency "toml", "~> 0.1.2"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/ruby/lib/helix_runtime/cli/templates/helix_runtime.rake
+++ b/ruby/lib/helix_runtime/cli/templates/helix_runtime.rake
@@ -1,5 +1,5 @@
 require 'helix_runtime/build_task'
 
-HelixRuntime::BuildTask.new("<%= app_name %>")
+HelixRuntime::BuildTask.new
 
 task :default => :build

--- a/ruby/lib/helix_runtime/parent_project.rb
+++ b/ruby/lib/helix_runtime/parent_project.rb
@@ -10,7 +10,7 @@ module HelixRuntime
     def projects
       @projects ||= Dir["#{root}/crates/*"]
                         .select{|f| File.exist?("#{f}/Cargo.toml") }
-                        .map{|d| Project.new(File.basename(d), d) }
+                        .map{|d| Project.new(d) }
     end
 
     def ensure_built!

--- a/ruby/lib/helix_runtime/project.rb
+++ b/ruby/lib/helix_runtime/project.rb
@@ -1,3 +1,5 @@
+require 'toml'
+
 module HelixRuntime
   class Project
 
@@ -8,20 +10,26 @@ module HelixRuntime
     end
 
     attr_accessor :root
-    attr_accessor :name
     attr_accessor :helix_lib_dir
     attr_accessor :debug_rust
     attr_accessor :build_root
 
-    def initialize(name, root)
+    def initialize(root)
       @root = find_root(root)
-      @name = name
       @debug_rust = ENV['DEBUG_RUST']
       @build_root = @root
     end
 
     def debug_rust?
       !!debug_rust
+    end
+
+    def name
+      @name ||= TOML.load_file(cargo_toml_path)["package"]["name"]
+    end
+
+    def cargo_toml_path
+      "#{root}/Cargo.toml"
     end
 
     def build_path

--- a/ruby/lib/helix_runtime/version.rb
+++ b/ruby/lib/helix_runtime/version.rb
@@ -1,5 +1,5 @@
 module HelixRuntime
   # Also update helix_runtime.c
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
   GEM_VERSION = VERSION.gsub("-", ".")
 end


### PR DESCRIPTION
Since we already have the `Cargo.toml`, we don't actually need the user to pass the project name. Further more, the build task doesn't actually work correctly if you pass any name _other than_ what is in your `Cargo.toml` (as seen in #92).

Fixes #110.

Tested in helix-flipper.