### PR TITLE
Fix missing .lib files when building libcruby-sys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,9 @@ script: |
         popd
 
         echo -e "Publishing libcruby-sys crate...\n"
+        # need to do this since there's a .gitignore with *.lib files
+        # there's a bug in Cargo, where include isn't overriding exclude
+        rm -rf .git
         pushd crates/libcruby-sys
         HELIX_LIB_DIR=$PWD cargo publish
         popd


### PR DESCRIPTION
There is a bug in Cargo, where `.gitignore` will override the include
directive in `Cargo.toml`. Since the `.gitignore` included `.lib`, the
`helix-runtime-*.x86_64.lib` and `helix-runtime-*.i386.lib` weren't being
packaged.