### PR TITLE
Need to use the right dlltool for the respective arch

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -46,16 +46,16 @@ end
 
 directory windows_build_dir
 
-def dlltool
+def dlltool(arch = nil)
   # allow override with env vars
   if dlltool_env = ENV['DLLTOOL']
     dlltool_env
   # if on windows
   elsif RUBY_PLATFORM =~ /mingw/
     "dlltool.exe"
-  elsif system("x86_64-w64-mingw32-dlltool > /dev/null")
+  elsif system("x86_64-w64-mingw32-dlltool > /dev/null") && arch == "i386:x86-64"
     "x86_64-w64-mingw32-dlltool"
-  elsif system("i686-w64-mingw32-dlltool > /dev/null")
+  elsif system("i686-w64-mingw32-dlltool > /dev/null") && arch == "i386"
     "i686-w64-mingw32-dlltool"
   else
     "dlltool"
@@ -66,7 +66,7 @@ def build_native_lib(arch, dll_name, native_def_file, target)
   Dir.mktmpdir do |dir|
     Dir.chdir(dir) do
       # Generate and then move. Symbols include generated file name, so avoid long path.
-      cmd = [dlltool]
+      cmd = [dlltool(arch)]
       cmd << "-D #{dll_name}"
       cmd << "-m #{arch}" if arch
       cmd << "-d #{native_def_file}"


### PR DESCRIPTION
Apparently, `-m` still includes some 64 bit objects when running
dlltool. It leads to a linking error when compiling on 32-bit windows:

```
helix-runtime-0-6-3.i386.lib(dnekh.o) : fatal error LNK1112: module
machine type 'x64' conflicts with target machine type 'X86'
```

When analyzing the 32-bit lib file, you can see the 64-bit objects.

```
$ objdump -f helix-runtime-0-6-2.i386.lib
In archive helix-runtime-0-6-2.i386.lib:

dfrzt.o:     file format pe-x86-64
architecture: i386:x86-64, flags 0x00000038:
HAS_DEBUG, HAS_SYMS, HAS_LOCALS
start address 0x0000000000000000

dfrzh.o:     file format pe-x86-64
architecture: i386:x86-64, flags 0x00000039:
HAS_RELOC, HAS_DEBUG, HAS_SYMS, HAS_LOCALS
start address 0x0000000000000000

dfrzs00056.o:     file format pe-i386
architecture: i386, flags 0x00000039:
HAS_RELOC, HAS_DEBUG, HAS_SYMS, HAS_LOCALS
start address 0x00000000
```

This fix ensures we only run the 32-bit dlltool when building the 32-bit
native lib file