### PR TITLE
Use `compile_errors!` to report parse errors

### DIFF
--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -30,51 +30,6 @@ macro_rules! item {
     ($it: item) => { $it }
 }
 
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! assert_struct {
-    (true, {
-        type: class,
-        rust_name: $rust_name:ident,
-        ruby_name: $ruby_name:tt,
-        meta: $meta:tt,
-        struct: { $($struct:tt)+ },
-        methods: $methods:tt
-    }) => {};
-
-    (false, {
-        type: class,
-        rust_name: $rust_name:ident,
-        ruby_name: $ruby_name:tt,
-        meta: $meta:tt,
-        struct: (),
-        methods: $methods:tt
-    }) => {};
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! assert_valid_self_arg {
-    (self) => {}
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! assert_valid_arg {
-    ($arg:ident) => {};
-    (_) => {};
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! assert_no_explict_return_for_initializer {
-    (instance_method, $($rest:tt)*) => {};
-    (class_method, $($rest:tt)*) => {};
-    (initializer, ) => {};
-}
-
-
 #[macro_export]
 macro_rules! throw {
     ($msg:expr) => {


### PR DESCRIPTION
Unfortunately, we will lose the span for these errors.

(See rust-lang/rust#44535)