### PR TITLE
Allow `to_ruby`  to fail

### DIFF
--- a/examples/calculator/spec/calculator_spec.rb
+++ b/examples/calculator/spec/calculator_spec.rb
@@ -10,6 +10,12 @@ describe Calculator do
     expect(Calculator.multiply(1.23, -4.56)).to eq(1.23 * -4.56)
     expect(Calculator.multiply(3, 5)).to eq(15)
   end
+
+  it "can divide numbers" do
+    expect(Calculator.divide(1.23, -4.56)).to eq(1.23 / -4.56)
+    expect(Calculator.divide(4, 2)).to eq(2)
+    expect { Calculator.divide(4, 0) }.to raise_error("Division by zero")
+  end
 end
 
 describe Adder do
@@ -23,5 +29,13 @@ describe Multiplier do
   it "can multiply numbers" do
     expect(Multiplier.new(1.23).(-4.56)).to eq(1.23 * -4.56)
     expect(Multiplier.new(3).(5)).to eq(15)
+  end
+end
+
+describe Divider do
+  it "can divide numbers" do
+    expect(Divider.new(1.23).(-4.56)).to eq(1.23 / -4.56)
+    expect(Divider.new(4).(2)).to eq(2)
+    expect { Divider.new(4).(0) }.to raise_error("Division by zero")
   end
 end

--- a/examples/calculator/src/lib.rs
+++ b/examples/calculator/src/lib.rs
@@ -12,6 +12,10 @@ ruby! {
         def multiply(lhs: f64, rhs: f64) -> f64 {
             Multiplier::new(lhs).call(rhs)
         }
+
+        def divide(lhs: f64, rhs: f64) -> Result<f64, &'static str> {
+            Divider::new(lhs).call(rhs)
+        }
     }
 
     class Adder {
@@ -39,6 +43,24 @@ ruby! {
 
         def call(&self, rhs: f64) -> f64 {
             self.lhs * rhs
+        }
+    }
+
+    class Divider {
+        struct {
+            lhs: f64
+        }
+
+        def initialize(helix, value: f64) {
+            Divider { helix, lhs: value }
+        }
+
+        def call(&self, rhs: f64) -> Result<f64, &'static str> {
+            if rhs == 0f64 {
+                Err("Division by zero")
+            } else {
+                Ok(self.lhs / rhs)
+            }
         }
     }
 }

--- a/src/coercions/bool.rs
+++ b/src/coercions/bool.rs
@@ -1,6 +1,6 @@
 use sys::{self, VALUE, Qtrue, Qfalse};
 
-use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby};
+use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby, ToRubyResult};
 
 impl UncheckedValue<bool> for VALUE {
     fn to_checked(self) -> CheckResult<bool> {
@@ -19,11 +19,11 @@ impl ToRust<bool> for CheckedValue<bool> {
 }
 
 impl ToRuby for bool {
-    fn to_ruby(self) -> VALUE {
+    fn to_ruby(self) -> ToRubyResult {
         if self {
-            unsafe { Qtrue }
+            Ok(unsafe { Qtrue })
         } else {
-            unsafe { Qfalse }
+            Ok(unsafe { Qfalse })
         }
     }
 }

--- a/src/coercions/float.rs
+++ b/src/coercions/float.rs
@@ -1,6 +1,6 @@
 use sys::{self, VALUE, T_FLOAT, T_FIXNUM, T_BIGNUM};
 
-use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby};
+use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby, ToRubyResult};
 
 impl UncheckedValue<f64> for VALUE {
     fn to_checked(self) -> CheckResult<f64> {
@@ -19,7 +19,7 @@ impl ToRust<f64> for CheckedValue<f64> {
 }
 
 impl ToRuby for f64 {
-    fn to_ruby(self) -> VALUE {
-        unsafe { sys::F642NUM(self) }
+    fn to_ruby(self) -> ToRubyResult {
+        Ok(unsafe { sys::F642NUM(self) })
     }
 }

--- a/src/coercions/integers.rs
+++ b/src/coercions/integers.rs
@@ -1,6 +1,6 @@
 use sys::{self, VALUE, T_FIXNUM, T_BIGNUM};
 
-use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby};
+use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby, ToRubyResult};
 
 impl UncheckedValue<u64> for VALUE {
     fn to_checked(self) -> CheckResult<u64> {
@@ -19,8 +19,8 @@ impl ToRust<u64> for CheckedValue<u64> {
 }
 
 impl ToRuby for u64 {
-    fn to_ruby(self) -> VALUE {
-        unsafe { sys::U642NUM(self) }
+    fn to_ruby(self) -> ToRubyResult {
+        Ok(unsafe { sys::U642NUM(self) })
     }
 }
 
@@ -41,8 +41,8 @@ impl ToRust<i64> for CheckedValue<i64> {
 }
 
 impl ToRuby for i64 {
-    fn to_ruby(self) -> VALUE {
-        unsafe { sys::I642NUM(self) }
+    fn to_ruby(self) -> ToRubyResult {
+        Ok(unsafe { sys::I642NUM(self) })
     }
 }
 
@@ -63,8 +63,8 @@ impl ToRust<u32> for CheckedValue<u32> {
 }
 
 impl ToRuby for u32 {
-    fn to_ruby(self) -> VALUE {
-        unsafe { sys::U322NUM(self) }
+    fn to_ruby(self) -> ToRubyResult {
+        Ok(unsafe { sys::U322NUM(self) })
     }
 }
 
@@ -85,7 +85,7 @@ impl ToRust<i32> for CheckedValue<i32> {
 }
 
 impl ToRuby for i32 {
-    fn to_ruby(self) -> VALUE {
-        unsafe { sys::I322NUM(self) }
+    fn to_ruby(self) -> ToRubyResult {
+        Ok(unsafe { sys::I322NUM(self) })
     }
 }

--- a/src/coercions/mod.rs
+++ b/src/coercions/mod.rs
@@ -5,8 +5,10 @@ mod bool;
 mod integers;
 mod float;
 mod option;
+mod result;
 
 use sys::{VALUE};
+use super::ExceptionInfo;
 use std::marker::PhantomData;
 
 pub struct CheckedValue<T> {
@@ -30,12 +32,14 @@ pub trait ToRust<T> {
     fn to_rust(self) -> T;
 }
 
+pub type ToRubyResult = Result<VALUE, ExceptionInfo>;
+
 pub trait ToRuby {
-    fn to_ruby(self) -> VALUE;
+    fn to_ruby(self) -> ToRubyResult;
 }
 
 impl ToRuby for VALUE {
-    fn to_ruby(self) -> VALUE {
-        self
+    fn to_ruby(self) -> ToRubyResult {
+        Ok(self)
     }
 }

--- a/src/coercions/option.rs
+++ b/src/coercions/option.rs
@@ -1,5 +1,5 @@
 use sys::{VALUE, Qnil};
-use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby};
+use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby, ToRubyResult};
 
 impl<T> UncheckedValue<Option<T>> for VALUE where VALUE: UncheckedValue<T> {
     fn to_checked(self) -> CheckResult<Option<T>> {
@@ -24,10 +24,10 @@ impl<T> ToRust<Option<T>> for CheckedValue<Option<T>> where CheckedValue<T>: ToR
 }
 
 impl<T> ToRuby for Option<T> where T: ToRuby {
-    fn to_ruby(self) -> VALUE {
+    fn to_ruby(self) -> ToRubyResult {
         match self {
             Some(value) => value.to_ruby(),
-            None => unsafe { Qnil }
+            None => Ok(unsafe { Qnil })
         }
     }
 }

--- a/src/coercions/result.rs
+++ b/src/coercions/result.rs
@@ -1,0 +1,10 @@
+use super::{ToRuby, ToRubyResult, ExceptionInfo};
+
+impl<T, U> ToRuby for Result<T, U> where T: ToRuby, U: ToRuby {
+    fn to_ruby(self) -> ToRubyResult {
+        match self {
+            Ok(value) => value.to_ruby(),
+            Err(message) => Err(ExceptionInfo::with_message(message))
+        }
+    }
+}

--- a/src/coercions/string.rs
+++ b/src/coercions/string.rs
@@ -3,7 +3,7 @@ use std;
 use sys;
 use sys::{VALUE};
 
-use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby};
+use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby, ToRubyResult};
 
 // VALUE -> to_coercible_rust<String> -> CheckResult<String> -> unwrap() -> Coercible<String> -> to_rust() -> String
 
@@ -27,17 +27,17 @@ impl ToRust<String> for CheckedValue<String> {
 }
 
 impl ToRuby for String {
-    fn to_ruby(self) -> VALUE {
+    fn to_ruby(self) -> ToRubyResult {
         let ptr = self.as_ptr();
         let len = self.len();
-        unsafe { sys::rb_utf8_str_new(ptr as *const libc::c_char, len as libc::c_long) }
+        Ok(unsafe { sys::rb_utf8_str_new(ptr as *const libc::c_char, len as libc::c_long) })
     }
 }
 
 impl<'a> ToRuby for &'a str {
-    fn to_ruby(self) -> VALUE {
+    fn to_ruby(self) -> ToRubyResult {
         let ptr = self.as_ptr();
         let len = self.len();
-        unsafe { sys::rb_utf8_str_new(ptr as *const libc::c_char, len as libc::c_long) }
+        Ok(unsafe { sys::rb_utf8_str_new(ptr as *const libc::c_char, len as libc::c_long) })
     }
 }

--- a/src/coercions/unit.rs
+++ b/src/coercions/unit.rs
@@ -1,8 +1,8 @@
-use sys::{self, VALUE};
-use ToRuby;
+use sys::{self};
+use super::{ToRuby, ToRubyResult};
 
 impl ToRuby for () {
-    fn to_ruby(self) -> VALUE {
-        unsafe { sys::Qnil }
+    fn to_ruby(self) -> ToRubyResult {
+        Ok(unsafe { sys::Qnil })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate cslice;
-
 #[allow(unused_imports)]
 #[macro_use]
 extern crate cstr_macro;
@@ -109,17 +107,17 @@ pub struct ExceptionInfo {
 }
 
 impl ExceptionInfo {
-    pub fn with_message<T: ToRuby>(string: T) -> ExceptionInfo {
-        ExceptionInfo {
-            exception: Class(unsafe { sys::rb_eRuntimeError }),
-            message: string.to_ruby(),
+    pub fn with_message<T: ToRuby>(reason: T) -> ExceptionInfo {
+        match reason.to_ruby() {
+            Ok(message) => ExceptionInfo { exception: Class(unsafe { sys::rb_eRuntimeError }), message },
+            Err(cause) => ExceptionInfo::with_message(format!("Unknown Error; cause={:?})", cause))
         }
     }
 
-    pub fn type_error<T: ToRuby>(string: T) -> ExceptionInfo {
-        ExceptionInfo {
-            exception: Class(unsafe { sys::rb_eTypeError }),
-            message: string.to_ruby(),
+    pub fn type_error<T: ToRuby>(reason: T) -> ExceptionInfo {
+        match reason.to_ruby() {
+            Ok(message) => ExceptionInfo { exception: Class(unsafe { sys::rb_eTypeError }), message },
+            Err(cause) => ExceptionInfo::with_message(format!("Unknown Error; cause={:?})", cause))
         }
     }
 

--- a/src/macros/coercions.rs
+++ b/src/macros/coercions.rs
@@ -44,8 +44,8 @@ macro_rules! codegen_coercions {
         impl_struct_to_rust!(&'a mut $rust_name, $rust_name);
 
         impl $crate::ToRuby for $rust_name {
-            fn to_ruby(self) -> $crate::sys::VALUE {
-                $rust_name::__alloc_with__(Some(Box::new(self)))
+            fn to_ruby(self) -> $crate::ToRubyResult {
+                Ok($rust_name::__alloc_with__(Some(Box::new(self))))
             }
         }
 
@@ -61,8 +61,8 @@ macro_rules! impl_to_ruby {
     ($rust_name:ty) => {
         item! {
             impl<'a> $crate::ToRuby for $rust_name {
-                fn to_ruby(self) -> $crate::sys::VALUE {
-                    self.helix
+                fn to_ruby(self) -> $crate::ToRubyResult {
+                    Ok(self.helix)
                 }
             }
         }

--- a/src/macros/init.rs
+++ b/src/macros/init.rs
@@ -113,10 +113,10 @@ macro_rules! codegen_define_method {
 
         #[inline]
         fn __rust_method__($($arg : $crate::sys::VALUE),*) -> CallResult {
-            let checked = __checked_call__($($arg),*);
+            let checked = __checked_call__($($arg),*).and_then($crate::ToRuby::to_ruby);
 
             match checked {
-                Ok(val) => CallResult { error_klass: unsafe { Qnil }, value: $crate::ToRuby::to_ruby(val) },
+                Ok(value) => CallResult { error_klass: unsafe { Qnil }, value },
                 Err(err) => CallResult { error_klass: err.exception.inner(), value: err.message }
             }
         }
@@ -185,10 +185,10 @@ macro_rules! codegen_define_method {
 
         #[inline]
         fn __rust_method__(rb_self: $crate::sys::VALUE, $($arg : $crate::sys::VALUE),*) -> CallResult {
-            let checked = __checked_call__(rb_self, $($arg),*);
+            let checked = __checked_call__(rb_self, $($arg),*).and_then($crate::ToRuby::to_ruby);
 
             match checked {
-                Ok(val) => CallResult { error_klass: unsafe { Qnil }, value: $crate::ToRuby::to_ruby(val) },
+                Ok(value) => CallResult { error_klass: unsafe { Qnil }, value },
                 Err(err) => CallResult { error_klass: err.exception.inner(), value: err.message }
             }
         }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -36,4 +36,3 @@ macro_rules! throw {
         panic!($crate::ExceptionInfo::with_message(String::from($msg)))
     }
 }
-


### PR DESCRIPTION
This switches the `to_ruby` trait method to return a `Result`, which allows the coercion to fail.

The most obvious use case for this is to implement coercion for the `Result` type in Rust (included in this PR), but there could be other reasons why a coercion might fail. For example, if we were to implement a coercion between a Rust and Ruby regular expression, the coercion could fail if the Rust regular expression uses some Rust-specific features that are not supported by the Ruby regular expression implementation.