### PR TITLE
Use 'tomlrb' instead of 'toml' gem

### DIFF
--- a/examples/calculator/Gemfile.lock
+++ b/examples/calculator/Gemfile.lock
@@ -4,16 +4,13 @@ PATH
     helix_runtime (0.6.4)
       rake (>= 10.0)
       thor (~> 0.19.4)
-      toml (~> 0.1.2)
+      tomlrb (~> 1.2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
     colorize (0.8.1)
     diff-lcs (1.3)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -29,8 +26,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thor (0.19.4)
-    toml (0.1.2)
-      parslet (~> 1.5.0)
+    tomlrb (1.2.4)
 
 PLATFORMS
   ruby
@@ -44,4 +40,4 @@ DEPENDENCIES
   rspec (~> 3.4)
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/examples/console/Gemfile.lock
+++ b/examples/console/Gemfile.lock
@@ -4,16 +4,13 @@ PATH
     helix_runtime (0.6.4)
       rake (>= 10.0)
       thor (~> 0.19.4)
-      toml (~> 0.1.2)
+      tomlrb (~> 1.2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
     colorize (0.8.1)
     diff-lcs (1.3)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -29,8 +26,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thor (0.19.4)
-    toml (0.1.2)
-      parslet (~> 1.5.0)
+    tomlrb (1.2.4)
 
 PLATFORMS
   ruby
@@ -44,4 +40,4 @@ DEPENDENCIES
   rspec (~> 3.4)
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/examples/duration/Gemfile.lock
+++ b/examples/duration/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     helix_runtime (0.6.4)
       rake (>= 10.0)
       thor (~> 0.19.4)
-      toml (~> 0.1.2)
+      tomlrb (~> 1.2.4)
 
 PATH
   remote: .
@@ -20,17 +20,13 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    blankslate (2.1.2.4)
     concurrent-ruby (1.0.5)
     i18n (0.8.1)
     minitest (5.8.3)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
     rake (10.5.0)
     thor (0.19.4)
     thread_safe (0.3.6)
-    toml (0.1.2)
-      parslet (~> 1.5.0)
+    tomlrb (1.2.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -48,4 +44,4 @@ DEPENDENCIES
   rake (~> 10.0)
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/examples/membership/Gemfile.lock
+++ b/examples/membership/Gemfile.lock
@@ -4,15 +4,12 @@ PATH
     helix_runtime (0.6.4)
       rake (>= 10.0)
       thor (~> 0.19.4)
-      toml (~> 0.1.2)
+      tomlrb (~> 1.2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
     diff-lcs (1.2.5)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
     rake (10.5.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -28,8 +25,7 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     thor (0.19.4)
-    toml (0.1.2)
-      parslet (~> 1.5.0)
+    tomlrb (1.2.4)
 
 PLATFORMS
   ruby
@@ -42,4 +38,4 @@ DEPENDENCIES
   rspec (~> 3.4)
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/examples/text_transform/Gemfile.lock
+++ b/examples/text_transform/Gemfile.lock
@@ -4,15 +4,12 @@ PATH
     helix_runtime (0.6.4)
       rake (>= 10.0)
       thor (~> 0.19.4)
-      toml (~> 0.1.2)
+      tomlrb (~> 1.2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
     diff-lcs (1.3)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -28,8 +25,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     thor (0.19.4)
-    toml (0.1.2)
-      parslet (~> 1.5.0)
+    tomlrb (1.2.4)
 
 PLATFORMS
   ruby
@@ -40,4 +36,4 @@ DEPENDENCIES
   rspec (~> 3.4)
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/examples/turbo_blank/Gemfile.lock
+++ b/examples/turbo_blank/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     helix_runtime (0.6.4)
       rake (>= 10.0)
       thor (~> 0.19.4)
-      toml (~> 0.1.2)
+      tomlrb (~> 1.2.4)
 
 PATH
   remote: .
@@ -15,14 +15,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    blankslate (2.1.2.4)
     minitest (5.8.3)
-    parslet (1.5.0)
-      blankslate (~> 2.0)
     rake (10.5.0)
     thor (0.19.4)
-    toml (0.1.2)
-      parslet (~> 1.5.0)
+    tomlrb (1.2.4)
 
 PLATFORMS
   ruby
@@ -37,4 +33,4 @@ DEPENDENCIES
   turbo_blank!
 
 BUNDLED WITH
-   1.14.6
+   1.15.3

--- a/ruby/helix_runtime.gemspec
+++ b/ruby/helix_runtime.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rake", ">= 10.0"
-  spec.add_dependency "thor", "~> 0.19.4"
-  spec.add_dependency "toml", "~> 0.1.2"
+  spec.add_dependency "rake",   ">= 10.0"
+  spec.add_dependency "thor",   "~> 0.19.4"
+  spec.add_dependency "tomlrb", "~> 1.2.4"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/ruby/lib/helix_runtime/project.rb
+++ b/ruby/lib/helix_runtime/project.rb
@@ -1,4 +1,4 @@
-require 'toml'
+require 'tomlrb'
 
 module HelixRuntime
   class Project
@@ -25,7 +25,7 @@ module HelixRuntime
     end
 
     def name
-      @name ||= TOML.load_file(cargo_toml_path)["package"]["name"]
+      @name ||= Tomlrb.load_file(cargo_toml_path)["package"]["name"]
     end
 
     def cargo_toml_path


### PR DESCRIPTION
The [`toml` gem](https://github.com/jm/toml) is kinda broken:

```shell
$ ruby -rtoml -e 'puts TOML.load("a = {}")'
Failed to match sequence (ALL_SPACE (TABLE / TABLE_ARRAY / KEY_VALUE / COMMENT_LINE){0, } ALL_SPACE) at line 1 char 1.
`- Don't know what to do with "a = {}\n" at line 1 char 1.
{}
```

Luckily, [`tomlrb`](https://github.com/fbernier/tomlrb) is not:
```shell
$ ruby -rtomlrb -e 'puts Tomlrb.parse("a = {}")'
{"a"=>{}}
```

This came to light when I was trying to implement Helix and got inscrutable parse errors because my `Cargo.toml` had an inline table in it.