### PR TITLE
Fix incorrect native_lib name format bug

### DIFF
--- a/ruby/lib/helix_runtime/project.rb
+++ b/ruby/lib/helix_runtime/project.rb
@@ -49,7 +49,7 @@ module HelixRuntime
     end
 
     def native_lib
-      "#{libfile_prefix}#{name.sub('-', '_')}.#{Platform.libext}"
+      "#{libfile_prefix}#{name.gsub('-', '_')}.#{Platform.libext}"
     end
 
     def outdated_build?


### PR DESCRIPTION
For project name with more then one '-' using `sub` will only replace
the first occurence. This cause `copy_native` to be failed due to
`File.exist?` check failed. Use `gsub` instead to fix.