### PR TITLE
Use the standard convention for function pointers in libcruby

### DIFF
--- a/crates/libcruby-sys/src/lib.rs
+++ b/crates/libcruby-sys/src/lib.rs
@@ -185,7 +185,7 @@ extern "C" {
     pub fn rb_define_module_under(namespace: VALUE, name: c_string) -> VALUE;
     pub fn rb_define_class(name: c_string, superclass: VALUE) -> VALUE;
     pub fn rb_define_class_under(namespace: VALUE, name: c_string, superclass: VALUE) -> VALUE;
-    pub fn rb_define_alloc_func(klass: VALUE, func: extern "C" fn(klass: VALUE) -> VALUE);
+    pub fn rb_define_alloc_func(klass: VALUE, func: Option<extern "C" fn(klass: VALUE) -> VALUE>);
     pub fn rb_define_method(class: VALUE, name: c_string, func: c_func, arity: isize);
     pub fn rb_define_singleton_method(class: VALUE, name: c_string, func: c_func, arity: isize);
     pub fn rb_sprintf(specifier: c_string, ...) -> VALUE;
@@ -200,17 +200,17 @@ extern "C" {
     pub fn rb_ary_push(ary: VALUE, item: VALUE) -> VALUE;
     pub fn rb_hash_new() -> VALUE;
     pub fn rb_hash_aset(hash: VALUE, key: VALUE, value: VALUE) -> VALUE;
-    pub fn rb_hash_foreach(hash: VALUE, f: extern "C" fn(key: VALUE, value: VALUE, farg: *mut void) -> st_retval, farg: *mut void);
+    pub fn rb_hash_foreach(hash: VALUE, f: Option<extern "C" fn(key: VALUE, value: VALUE, farg: *mut void) -> st_retval>, farg: *mut void);
 
     pub fn rb_raise(exc: VALUE, string: c_string, ...) -> !;
     pub fn rb_jump_tag(state: RubyException) -> !;
-    pub fn rb_protect(try: extern "C" fn(v: *mut void) -> VALUE,
+    pub fn rb_protect(try: Option<extern "C" fn(v: *mut void) -> VALUE>,
                       arg: *mut void,
                       state: *mut RubyException)
                       -> VALUE;
 
     #[link_name = "HELIX_Data_Wrap_Struct"]
-    pub fn Data_Wrap_Struct(klass: VALUE, mark: extern "C" fn(*mut void), free: extern "C" fn(*mut void), data: *mut void) -> VALUE;
+    pub fn Data_Wrap_Struct(klass: VALUE, mark: Option<extern "C" fn(*mut void)>, free: Option<extern "C" fn(*mut void)>, data: *mut void) -> VALUE;
 
     #[link_name = "HELIX_Data_Get_Struct_Value"]
     pub fn Data_Get_Struct_Value(obj: VALUE) -> *mut void;

--- a/src/class_definition.rs
+++ b/src/class_definition.rs
@@ -34,7 +34,7 @@ impl ClassDefinition {
 
     pub fn wrapped(name: c_string, alloc_func: extern "C" fn(klass: sys::VALUE) -> sys::VALUE) -> ClassDefinition {
         let raw_class = unsafe { sys::rb_define_class(name, sys::rb_cObject) };
-        unsafe { sys::rb_define_alloc_func(raw_class, alloc_func) };
+        unsafe { sys::rb_define_alloc_func(raw_class, Some(alloc_func)) };
         ClassDefinition { class: Class(raw_class) }
     }
 

--- a/src/coercions/hash.rs
+++ b/src/coercions/hash.rs
@@ -18,7 +18,7 @@ impl<K: FromRuby + Eq + Hash, V: FromRuby> FromRuby for HashMap<K, V> {
             let len = unsafe { RHASH_SIZE(value) };
 
             let mut pairs = Vec::<(VALUE, VALUE)>::with_capacity(len as usize);
-            unsafe { rb_hash_foreach(value, rb_hash_collect, transmute(&mut pairs)) };
+            unsafe { rb_hash_foreach(value, Some(rb_hash_collect), transmute(&mut pairs)) };
 
             let mut checked = Vec::<(K::Checked, V::Checked)>::with_capacity(len as usize);
 


### PR DESCRIPTION
Typically you never take `extern "C" fn` directly, as there is no way to
pass `NULL` there without using transmute. Bindgen and most other tools
generally use `Option` for this purpose.

I've also changed the alloc and free functions to use the functions
provided on box for converting to/from pointers, rather than relying on
its internal representation. There's still the `transmute` on the class,
but I'm not entirely sure what that's doing so I've left it alone for
now.