### PR TITLE
impl `Sync` for `ID`

### DIFF
--- a/crates/libcruby-sys/src/lib.rs
+++ b/crates/libcruby-sys/src/lib.rs
@@ -25,6 +25,8 @@ pub type c_string = *const libc::c_char;
 #[derive(Eq, PartialEq, Hash, Copy, Clone, Debug)]
 pub struct ID(*mut void);
 
+unsafe impl Sync for ID {}
+
 #[repr(C)]
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub struct VALUE(*mut void);


### PR DESCRIPTION
While we may be treating the representation of this type as opaque, I
think we can reasonably assume that it will never change to anything
that isn't `Sync`.

I think it may be worth considering making `VALUE` be `Sync` as well.
Even though it is effectively a pointer, it's a pointer to a *Ruby*
object, and therefore subject to the GVL.