### PR TITLE
Expose `T_DATA` in libcruby

### DIFF
--- a/crates/libcruby-sys/src/lib.rs
+++ b/crates/libcruby-sys/src/lib.rs
@@ -175,6 +175,9 @@ extern "C" {
     #[link_name = "HELIX_T_BIGNUM"]
     pub static T_BIGNUM: isize;
 
+    #[link_name = "HELIX_T_DATA"]
+    pub static T_DATA: isize;
+
     // unknown if working?
     // fn rb_define_variable(name: c_string, value: *const VALUE);
     pub fn rb_obj_class(obj: VALUE) -> VALUE;


### PR DESCRIPTION
This is already re-exported by the runtime, but was missing a Rust
binding.