### PR TITLE
trait objects without an explicit `dyn` are deprecated

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,7 @@ impl Error {
         Error { class: unsafe { Class(rb_eRuntimeError) }, message: ErrorMessage::Dynamic(message) }
     }
 
-    pub fn from_any(any: Box<any::Any>) -> Error {
+    pub fn from_any(any: Box<dyn any::Any>) -> Error {
         any.downcast::<Error>()
             .map(|e| *e)
             .or_else(|any| any.downcast::<&str>().map(|e| e.to_error()))


### PR DESCRIPTION
Noticed this while tinkering

warning: trait objects without an explicit `dyn` are deprecated
  --> src/errors.rs:26:30
   |
26 |     pub fn from_any(any: Box<any::Any>) -> Error {
   |                              ^^^^^^^^ help: use `dyn`: `dyn any::Any`
   |
   = note: `#[warn(bare_trait_objects)]` on by default